### PR TITLE
Protect against Slowloris-style attack

### DIFF
--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -9,6 +9,16 @@
 
 constexpr int PORT_STRLEN = 12;
 constexpr uint64_t	CLIENT_TIMEOUT_MS = 1000; /* One (1) second */
+constexpr uint64_t	RECV_HEADER_TIMEOUT_MS = 1000; /* One (1) second */
+
+#ifdef __linux__
+constexpr int MAXCONNS = 1024;
+static_assert(MAXCONNS <= 1024); // Haven't tested more than 1024 on Linux
+#else
+constexpr int MAXCONNS = 2048;
+static_assert(MAXCONNS <= 2048); // It won't go past this on macOS?
+#endif
+
 
 enum ConnectionState {
 	CONNECTION_DISCONNECTED,
@@ -34,9 +44,6 @@ class Endpoint {
 int		start_servers(std::vector<Configuration> servers, Endpoint *endpoints,
 		int endpoints_count_max, int *endpoints_count);
 void	cleanup(Endpoint *endpoints, int endpoints_count, int qfd);
-
-constexpr int MAXCONNS = 1024;
-static_assert(MAXCONNS <= 1024); /* Might not make sense to go past FD limit */
 
 Endpoint	*connectNewClient(HttpConnectionHandler *handlers, const Endpoint *endp, int qfd);
 void		receiveHeader(Endpoint *client, int qfd);

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -91,7 +91,7 @@ Endpoint	*connectNewClient(Endpoint *endpoints, const Endpoint *server, int qfd)
 		while (i < MAXCONNS)
 		{
 			Endpoint *conn = &endpoints[i];
-			bool client_sending_header_suspiciously_slowly = conn->state == CONNECTION_RECV_HEADER && now_ms() - conn->began_sending_header_ms > 3000;
+			bool client_sending_header_suspiciously_slowly = conn->state == CONNECTION_RECV_HEADER && now_ms() - conn->began_sending_header_ms > RECV_HEADER_TIMEOUT_MS;
 			if (client_sending_header_suspiciously_slowly)
 			{
 				disconnectClient(conn, qfd);

--- a/test_ddos/main.c
+++ b/test_ddos/main.c
@@ -15,7 +15,9 @@ static void	die(const char *err_msg);
 static int	socket_set_nonblocking(int sock);
 
 # define WORKERS_COUNT 10000
-# define REQUESTS_PER_WORKER 1000
+# define REQUESTS_PER_WORKER 2000
+# define CONN_DELAY_MICROSECONDS 25
+
 int	main(int argc, char **argv)
 {
 	signal(SIGPIPE, SIG_IGN);
@@ -31,7 +33,7 @@ int	main(int argc, char **argv)
 	for (int i = 0; i < WORKERS_COUNT; i++)
 	{
 		pthread_create(&workers[i], NULL, talk_slow, argv);
-		usleep(5000);
+		usleep(CONN_DELAY_MICROSECONDS);
 	}
 	for (int i = 0; i < WORKERS_COUNT; i++)
 		pthread_join(workers[i], NULL);


### PR DESCRIPTION
If a bunch of clients connect all at once and start sending headers very slowly, we run out of connections and crash.
The new system will, when in the situation where all connection slots are used up, find a client that has been sending a header for a suspiciously long time, disconnect them, and reclaim the connection.
The header timeout is one second, which is actually not a long time at all, but HTTP headers are normally at most a couple hundred bytes, so it shouldn't take that long. I would like to increase that timeout to something more reasonable but that would involve more sophisticated protection. WIP.
In the case where we run out of connection and have to kick someone out, it's an urgent crisis situation, so we don't send 408. We just evict them. There needs to be another timeout mechanism for when we have more room but we just don't want to keep the client connected, where we go through the proper bureaucracy to send 408. That's also WIP.