### PR TITLE
Return 500 on CGI timeout

### DIFF
--- a/src/CgiHandler.cpp
+++ b/src/CgiHandler.cpp
@@ -3,6 +3,7 @@
 #include "Configuration.hpp"
 #include "Logger.hpp"
 #include <sys/wait.h>
+#include <signal.h>
 
 int*		CgiHandler::getPipeToCgi() { return _pipeToCgi; };
 int*		CgiHandler::getPipeFromCgi() { return _pipeFromCgi; };

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -209,8 +209,10 @@ static bool	isTimedOut(Endpoint *conn, int qfd)
     logDebug("%d idle for %zums, timing out soon", conn->sockfd, idle_duration_ms);
 
 	if (conn->handler.getErrorCode() != 408
+      && conn->handler.getErrorCode() != 500
 			&&  idle_duration_ms > CLIENT_TIMEOUT_THRESHOLD_MS) {
-		conn->handler.setErrorCode(408);
+		conn->handler.setErrorCode(
+        conn->cgiHandler.cgiPid == 0 ? 408 : 500);
 		logDebug("Soft timeout: %d", conn->sockfd);
 		return (true);
 	}


### PR DESCRIPTION
The previous version would return a client error if a CGI program is misbehaving, which is wrong in my opinion, so we 500 now in that case.